### PR TITLE
Fallback to MaxClients if MaxRequestsWorkers not found

### DIFF
--- a/apache2buddy.pl
+++ b/apache2buddy.pl
@@ -1978,6 +1978,10 @@ sub preflight_checks {
 	if ( our $apache_version =~ m/.*\s*\/2.4.*/) {
 		our $maxclients = find_master_value(\@config_array, $model, 'maxrequestworkers');
 		if($maxclients eq 'CONFIG NOT FOUND') {
+      # Fallback to MaxClients if MaxRequestsPerWorker not found
+      $maxclients = find_master_value(\@config_array, $model, 'maxclients');
+    }
+		if($maxclients eq 'CONFIG NOT FOUND') {
 			if ( ! $NOWARN ) { show_warn_box; print "MaxRequestWorkers directive not found, assuming default values.\n" }
 			if ( $model eq "prefork") {
 				# Default for prefork - see http://httpd.apache.org/docs/2.4/mod/mpm_common.html#maxrequestworkers


### PR DESCRIPTION
https version 2.4 replaced MaxClients with MaxRequestWorkers.
Apache2buddy.pl followed this and looks for MaxRequestWorkers instead or sets a default of 256 if not found.

However the old directive is still supported:
https://httpd.apache.org/docs/2.4/mod/mpm_common.html
"
MaxRequestWorkers was called MaxClients before version 2.3.13. The old name is still supported.
"
And config files are still in use for 2.4 which use MaxClients instead of the newer MaxRequestWorkers. 