### PR TITLE
Fix error getting a list of pids

### DIFF
--- a/apache2buddy.pl
+++ b/apache2buddy.pl
@@ -858,7 +858,7 @@ sub get_memory_usage {
 	print "VERBOSE: Get '".$search_type."' memory usage\n" if $main::VERBOSE;
 
 	# get a list of the pid's for apache running as the appropriate user
-	my @pids = `ps aux | grep $process_name | grep "^$apache_user\s" | awk \'{ print \$2 }\'`;
+	my @pids = `ps aux | grep $process_name | grep "^$apache_user\\s" | awk \'{ print \$2 }\'`;
 
         # if length of @pids is still zero then die with an error.
 	if (@pids == 0) {

--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ CHANGELOG
 
 When		Who		What
 ======================================================================================
+2020-05-31	"pes-soft"	Fix error getting the list of pids introduced in #327
 2020-05-31	"pes-soft"	Add compatibility for Apache 2.4 from CentOS7
 				Software Collections #327
 2020-03-27	Richard Forth	Closes #319.

--- a/md5sums.txt
+++ b/md5sums.txt
@@ -1,1 +1,1 @@
-86dc406aa3cb9198e99ca13f9c12912f  apache2buddy.pl
+c38212fce3c3cff7fdf575e9142dbd1d  apache2buddy.pl

--- a/sha256sums.txt
+++ b/sha256sums.txt
@@ -1,1 +1,1 @@
-139cce69d1c7d72c355ad369e2163134290c2b1c8c87de6a9acdd9b0aa8a15b6  apache2buddy.pl
+d5515ad3b0c1f59a2f900cd6a16dc7911918ac31c3e3a9a6cb28e551f8d1e85c  apache2buddy.pl


### PR DESCRIPTION
PR #327 introduced an error in getting a list of pids by missing correct escaping of meta-character. This PR fixes it. Hash files and changelog updates are provided. Feel free to adapt changelog or code fix as necessary. Thank you.