### PR TITLE
feat: Add SLES12 compatibility

### DIFF
--- a/apache2buddy.pl
+++ b/apache2buddy.pl
@@ -987,6 +987,9 @@ sub test_process {
 	} elsif ( $process_name eq '/usr/sbin/apache2' ) {
 		@output = `LANGUAGE=en_GB.UTF-8 /usr/sbin/apache2ctl -V 2>&1 | grep "Server version"`;
 		print "VERBOSE: First line of output from \"/usr/sbin/apache2ctl -V\": $output[0]\n" if $main::VERBOSE;
+    } elsif ( $process_name eq '/usr/sbin/httpd-prefork' ) {
+	    @output = `LANGUAGE=en_GB.UTF-8 /usr/sbin/apache2ctl -V 2>&1 | grep "Server version"`;
+       print "VERBOSE: First line of output from \"/usr/sbin/apache2ctl -V\": $output[0]\n" if $main::VERBOSE;
 	} elsif ( $process_name eq '/usr/local/apache/bin/httpd' ) {
 		if ( ! $NOWARN ) { show_warn_box(); print "${RED}Apache seems to have been installed from source, its technically unsupported, we may get errors${ENDC}\n" }
 		@output = `LANGUAGE=en_GB.UTF-8 $process_name -V 2>&1 | grep "Server version"`;
@@ -1886,7 +1889,7 @@ sub preflight_checks {
 			 $apache_user_config =~ s/^\s*(.*?)\s*$/$1/;; # address issue #19, strip whitespace from both sides.
 		}
 	}  
-	unless ($apache_user_config eq "apache" or $apache_user_config eq "www-data") {
+	unless ($apache_user_config eq "apache" or $apache_user_config eq "www-data" or ($apache_user_config eq "wwwrun" and $distro eq "SUSE Linux Enterprise Server")) {
                 my $apache_config_userid = `id -u $apache_user_config`;
                 chomp($apache_config_userid);
                 # account for 'apache\x{d}' strangeness
@@ -2447,6 +2450,8 @@ sub detect_maxclients_hits {
 		our $maxclients_hits = `grep -i reached /usr/local/apache/logs/error_log | egrep -v "mod" | tail -5`;
 	} elsif ($process_name eq "/opt/apache2/bin/httpd") {
 		our $maxclients_hits = `find /opt/apache2/logs -name "error*" | tail -1 | xargs grep -i reached | egrep -v "mod" | tail -5`;
+	} elsif ($process_name eq "/usr/sbin/httpd-prefork") {
+       our $maxclients_hits = `find /var/log/apache2 -name "error*" | tail -1 | xargs grep -i reached | egrep -v "mod" | tail -5`;
 	} else {
 		# general ToDo would be `'grep "^ErrorLog " $apache_conf_file'`;
 		# to get configuration like:

--- a/changelog
+++ b/changelog
@@ -2,6 +2,9 @@ CHANGELOG
 
 When		Who		What
 ======================================================================================
+2021-11-03	Emil Cazamir	Added SuSE Linux v.12 compatibility 
+				Using httpd/apache2 running in prefork mode, tested 
+				with SLES 12 SP5
 2021-10-28	w4zu            Add support for Debian 11
 2021-02-22	Richard Forth   Added an important message about
 				Domain expiry and non renewal, and the risks

--- a/md5sums.txt
+++ b/md5sums.txt
@@ -1,1 +1,1 @@
-70a772a2fe329f999a1cb9bf606a11ef  apache2buddy.pl
+cd9a2e8d79e23ac5360abffe7e6026b9  apache2buddy.pl

--- a/sha256sums.txt
+++ b/sha256sums.txt
@@ -1,1 +1,1 @@
-5950c385ca2536b582d673538ae8147e4b735235af85074cc02372503f1ced7c  apache2buddy.pl
+0d137217ef188acd36ae2abcc8eb39187c14dcd9ccff6aec36fdc5ebf4d3e5b2  apache2buddy.pl


### PR DESCRIPTION
Here's the code needed to make this script run fine on Suse Linux Enterprise Server v. 12.

Tested on a SLES12 machine.

Please add this to the main code line, if you plan to better support SuSE servers.