### PR TITLE
Testing AmazonLinux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,18 @@ pipeline {
                 sh '/usr/sbin/httpd -k start && curl -sL https://raw.githubusercontent.com/richardforth/apache2buddy/staging/apache2buddy.pl | perl - -n'
             }
         }
+	stage('Docker AmazonLinux Staging') { 
+            agent { 
+                docker {
+                    image 'forric/amazonlinux:latest'
+                    args '-u root:root --cap-add SYS_PTRACE'
+                    reuseNode true
+                } 
+            }
+            steps {
+                sh '/usr/sbin/httpd -k start && curl -sL https://raw.githubusercontent.com/richardforth/apache2buddy/staging/apache2buddy.pl | perl - -n'
+            }
+        }
         stage('Docker Debian9 Staging') { 
             agent { 
                 docker {

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 [![Generic badge](https://img.shields.io/badge/Ubuntu%2018.04-Passing-Green.svg)](https://shields.io/) [![Generic badge](https://img.shields.io/badge/Ubuntu%2020.04-Passing-Green.svg)](https://shields.io/)
 
+[![Generic badge](https://img.shields.io/badge/AmazonLinux-Pending-red.svg)](https://shields.io/)
+
+
 The rule of thumb is if its not listed, its not supported.
 
 # execution

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Status
-[![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/richardforth/apache2buddy/graphs/commit-activity) [![GitHub latest commit](https://badgen.net/github/last-commit/richardforth/apache2buddy)](https://GitHub.com/richardforth/apache2buddy/commit/) [![GitHub stars](https://badgen.net/github/stars/richardforth/apache2buddy)](https://GitHub.com/richardforth/apache2buddy/stargazers/) [![Generic badge](https://img.shields.io/badge/Tests-Passing-Green.svg)](https://shields.io/)
+[![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/richardforth/apache2buddy/graphs/commit-activity) [![GitHub latest commit](https://badgen.net/github/last-commit/richardforth/apache2buddy)](https://GitHub.com/richardforth/apache2buddy/commit/) [![GitHub stars](https://badgen.net/github/stars/richardforth/apache2buddy)](https://GitHub.com/richardforth/apache2buddy/stargazers/) [![Generic badge](https://img.shields.io/badge/Tests-Failing%20Amazon%20Linux-red.svg)](https://shields.io/)
 
 # Supported OSes
 

--- a/apache2buddy.pl
+++ b/apache2buddy.pl
@@ -382,7 +382,7 @@ except ModuleNotFoundError as e:
                 show_crit_box(); print "Unable to locate the any 'python' binary. This script requires python to determine the Operating System and Version.\n";
                 show_info_box(); print "${YELLOW}To fix this make sure the python2 or python3 package is installed.${ENDC}\n";
         }
-        exit;
+        exit 1;
 
         # XXX instead of calling exit() we can:
         # @main::os_platform = ( 'Unknown Distro', '0.0', '' );

--- a/changelog
+++ b/changelog
@@ -2,6 +2,9 @@ CHANGELOG
 
 When		Who		What
 ======================================================================================
+2022-03-29	Richard Forth   Adding support for AmazonLinux
+				- Tests Failing Currently
+				- Work in progress
 2022-03-28	Richard Forth   Added support for Alma Linux 8 
 				- Tests Passing
 2022-03-28	Richard Forth   Added support for Rocky Linux 8

--- a/md5sums.txt
+++ b/md5sums.txt
@@ -1,1 +1,1 @@
-cf95bfea7d4e344aee9477df3c9f23d8  apache2buddy.pl
+eddf201abc7d8fb48662e2b1dafe4d88  apache2buddy.pl

--- a/sha256sums.txt
+++ b/sha256sums.txt
@@ -1,1 +1,1 @@
-0d0edb009b318c8d706641aeba1e33f92249cde387c7e2dcfd5bad8869ea5bb0  apache2buddy.pl
+1bd8de319b807f3944aa106fb931c705076a6a5c729d6ddea2bb5f067087b922  apache2buddy.pl


### PR DESCRIPTION
tests are currently failing due to missing dependencies not available in the AmazonLinux repos (python3-distro)